### PR TITLE
Allowed protocols

### DIFF
--- a/django_bleach/forms.py
+++ b/django_bleach/forms.py
@@ -37,8 +37,8 @@ class BleachField(forms.CharField):
     widget = default_widget
 
     def __init__(self, allowed_tags=None, allowed_attributes=None,
-                 allowed_styles=None, strip_comments=None, strip_tags=None,
-                 *args, **kwargs):
+                 allowed_styles=None, allowed_protocols=None,
+                 strip_comments=None, strip_tags=None, *args, **kwargs):
 
         self.widget = default_widget
 
@@ -52,6 +52,8 @@ class BleachField(forms.CharField):
             self.bleach_options['attributes'] = allowed_attributes
         if allowed_styles is not None:
             self.bleach_options['styles'] = allowed_styles
+        if allowed_protocols is not None:
+            self.bleach_options['protocols'] = allowed_protocols
         if strip_tags is not None:
             self.bleach_options['strip'] = strip_tags
         if strip_comments is not None:

--- a/django_bleach/models.py
+++ b/django_bleach/models.py
@@ -7,8 +7,8 @@ from .utils import get_bleach_default_options
 
 class BleachField(models.TextField):
     def __init__(self, allowed_tags=None, allowed_attributes=None,
-                 allowed_styles=None, strip_tags=None, strip_comments=None,
-                 *args, **kwargs):
+                 allowed_styles=None, allowed_protocols=None,
+                 strip_tags=None, strip_comments=None, *args, **kwargs):
 
         super(BleachField, self).__init__(*args, **kwargs)
 
@@ -20,6 +20,8 @@ class BleachField(models.TextField):
             self.bleach_kwargs['attributes'] = allowed_attributes
         if allowed_styles:
             self.bleach_kwargs['styles'] = allowed_styles
+        if allowed_protocols:
+            self.bleach_kwargs['protocols'] = allowed_protocols
         if strip_tags:
             self.bleach_kwargs['strip'] = strip_tags
         if strip_comments:

--- a/django_bleach/utils.py
+++ b/django_bleach/utils.py
@@ -13,6 +13,9 @@ def get_bleach_default_options():
     if hasattr(settings, "BLEACH_ALLOWED_STYLES"):
         bleach_args["styles"] = settings.BLEACH_ALLOWED_STYLES
 
+    if hasattr(settings, "BLEACH_ALLOWED_PROTOCOLS"):
+        bleach_args["protocols"] = settings.BLEACH_ALLOWED_PROTOCOLS
+
     if hasattr(settings, "BLEACH_STRIP_TAGS"):
         bleach_args["strip"] = settings.BLEACH_STRIP_TAGS
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -24,6 +24,11 @@ completely optional::
     BLEACH_ALLOWED_STYLES = [
         'font-family', 'font-weight', 'text-decoration', 'font-variant']
 
+    # Which protocols (and pseudo-protocols) are allowed in 'src' attributes
+    # (assuming src is an allowed attribute)
+    BLEACH_ALLOWED_PROTOCOLS = [
+        'http', 'https', 'data']
+
     # Strip unknown tags if True, replace with HTML escaped characters if False
     BLEACH_STRIP_TAGS = True
 
@@ -37,6 +42,7 @@ override as a named parameter to the ``BleachField``::
 * ``allowed_tags``
 * ``allowed_attributes``
 * ``allowed_styles``
+* ``allowed_protocols``
 * ``strip_tags``
 * ``strip_comments``
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -31,6 +31,7 @@ See the bleach documentation for their use:
 * ``allowed_tags``
 * ``allowed_attributes``
 * ``allowed_styles``
+* ``allowed_protocols``
 * ``strip_tags``
 * ``strip_comments``
 

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,11 @@ setup(
     license='MIT',
     packages=find_packages(),
     install_requires=[
-        'bleach',
+        'bleach>=1.5.0',
         'Django>=1.8',
     ],
     tests_require=[
-        'bleach',
+        'bleach>=1.5.0',
         'tox'
     ],
     cmdclass={'test': Tox},

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open(path.join(this_directory, 'README.rst')) as f:
 
 setup(
     name='django-bleach',
-    version="0.4.1",
+    version="0.4.2",
     description='Easily use bleach with Django models and templates',
     long_description=long_description,
     author='Mark Walker',

--- a/testproject/forms.py
+++ b/testproject/forms.py
@@ -15,6 +15,12 @@ ALLOWED_ATTRIBUTES = {
     'ul': ['class']
 }
 
+ALLOWED_PROTOCOLS = [
+    'http',
+    'https',
+    'data',
+]
+
 
 class BleachForm(forms.Form):
     """ Form for testing BleachField """
@@ -34,4 +40,11 @@ class BleachForm(forms.Form):
         strip_tags=False,
         allowed_tags=ALLOWED_TAGS,
         allowed_attributes=ALLOWED_ATTRIBUTES
+    )
+    bleach_attrs = BleachField(
+        max_length=100,
+        strip_tags=False,
+        allowed_tags=ALLOWED_TAGS,
+        allowed_attributes=ALLOWED_ATTRIBUTES,
+        allowed_protocols=ALLOWED_PROTOCOLS
     )


### PR DESCRIPTION
This adds support for Bleach's allowed protocols argument, added in [this PR](https://github.com/mozilla/bleach/pull/149).

Since that PR was merged for bleach `v1.5.0`, I adjusted the requirements in `setup.py` to require `>=1.5.0`.

I also bumped the version number by a micro version to make it easier for you to deploy a new version to PyPI.

I'm happy to answer any questions you might have. Thanks for this project!