### PR TITLE
Don't clean None form field values

### DIFF
--- a/django_bleach/forms.py
+++ b/django_bleach/forms.py
@@ -67,4 +67,12 @@ class BleachField(forms.CharField):
         """
         Strips any dodgy HTML tags from the input
         """
+        if value in self.empty_values:
+            try:
+                return self.empty_value
+            except AttributeError:
+                # CharField.empty_value was introduced in Django 1.11; in prior
+                # versions a unicode string was returned for empty values in
+                # all cases.
+                return u''
         return bleach.clean(value, **self.bleach_options)

--- a/django_bleach/tests/test_forms.py
+++ b/django_bleach/tests/test_forms.py
@@ -8,9 +8,9 @@ class TestBleachField(TestCase):
 
     def test_empty(self):
         """ Test no data """
-        with self.assertRaises(TypeError):
-            form = BleachForm(data={})
-            form.is_valid()
+        form = BleachForm(data={})
+        form.is_valid()
+        self.assertEqual(form.fields['no_tags'].to_python(None), u'')
 
     def test_bleaching(self):
         """ Test values are bleached """


### PR DESCRIPTION
This PR resolves #6 by checking for empty values and if found returning `self.empty_value` and skipping the clean. For Django <= 1.10 an empty unicode string is returned. Both behaviours are modeled on `CharField` behaviour.