### PR TITLE
Allows BleachField to be blank or null

### DIFF
--- a/django_bleach/models.py
+++ b/django_bleach/models.py
@@ -28,9 +28,12 @@ class BleachField(models.TextField):
             self.bleach_kwargs['strip_comments'] = strip_comments
 
     def pre_save(self, model_instance, add):
-        clean_value = clean(
-            getattr(model_instance, self.attname),
-            **self.bleach_kwargs
-        )
-        setattr(model_instance, self.attname, clean_value)
-        return clean_value
+        data = getattr(model_instance, self.attname)
+        if data:
+            clean_value = clean(
+                data,
+                **self.bleach_kwargs
+            )
+            setattr(model_instance, self.attname, clean_value)
+            return clean_value
+        return data

--- a/django_bleach/tests/test_models.py
+++ b/django_bleach/tests/test_models.py
@@ -47,3 +47,40 @@ class TestBleachModelField(TestCase):
         for key, value in test_data.items():
             obj = BleachContent.objects.create(content=value)
             self.assertEqual(obj.content, expected_values[key])
+
+
+class BleachNullableContent(models.Model):
+    """ Bleach test model"""
+    content = BleachField(
+        allowed_attributes=ALLOWED_ATTRIBUTES,
+        allowed_protocols=ALLOWED_PROTOCOLS,
+        allowed_styles=ALLOWED_STYLES,
+        allowed_tags=ALLOWED_TAGS,
+        strip_comments=True,
+        strip_tags=True,
+        blank=True,
+        null=True
+    )
+
+
+class TestBleachNullableModelField(TestCase):
+    """ Test model field """
+
+    def test_bleaching(self):
+        """ Test values are bleached """
+        test_data = {
+            'none': None,
+            'empty': "",
+            'whitespaces': "   ",
+            'linebreak': "\n",
+        }
+        expected_values = {
+            'none': None,
+            'empty': "",
+            'whitespaces': "   ",
+            'linebreak': "\n",
+        }
+
+        for key, value in test_data.items():
+            obj = BleachNullableContent.objects.create(content=value)
+            self.assertEqual(obj.content, expected_values[key])


### PR DESCRIPTION
# Feature description
`BleachField` now accepts nullable or blank values.
 - Added tests

# Tested on
Python 3.6+ 
Django==1.11.20
bleach==3.1.0

# Bug cause
As happened on #6, due to bleach changes [here](https://github.com/mozilla/bleach/blob/master/CHANGES#L239-L240) `clean` didn't accept `None` values. That caused any model with a nullable `BleachField` to raise an exception like this one:

> TypeError: argument cannot be of 'NoneType' type, must be of text type