### PR TITLE
Handle None as an input value in template tags

### DIFF
--- a/django_bleach/templatetags/bleach_tags.py
+++ b/django_bleach/templatetags/bleach_tags.py
@@ -12,7 +12,7 @@ register = template.Library()
 def bleach_value(value, tags=None):
     if value is None:
         return None
-    
+
     bleach_args = get_bleach_default_options()
     if tags is not None:
         args = bleach_args.copy()
@@ -37,5 +37,5 @@ def bleach_linkify(value):
     """
     if value is None:
         return None
-    
+
     return bleach.linkify(value, parse_email=True)

--- a/django_bleach/templatetags/bleach_tags.py
+++ b/django_bleach/templatetags/bleach_tags.py
@@ -10,6 +10,9 @@ register = template.Library()
 
 @register.filter(name='bleach')
 def bleach_value(value, tags=None):
+    if value is None:
+        return None
+    
     bleach_args = get_bleach_default_options()
     if tags is not None:
         args = bleach_args.copy()
@@ -32,4 +35,7 @@ def bleach_linkify(value):
         2. urls found in attributes
         3. email addresses
     """
+    if value is None:
+        return None
+    
     return bleach.linkify(value, parse_email=True)

--- a/django_bleach/tests/test_templatetags.py
+++ b/django_bleach/tests/test_templatetags.py
@@ -20,6 +20,21 @@ class TestBleachTemplates(TestCase):
             rendered_template
         )
 
+    def test_bleaching_none(self):
+        """ Test that None is handled properly as an input """
+        context = Context(
+            {'none_value': None}
+        )
+        template_to_render = Template(
+            '{% load bleach_tags %}'
+            '{{ none_value|bleach }}'
+        )
+        rendered_template = template_to_render.render(context)
+        self.assertEqual(
+            'None',
+            rendered_template
+        )
+
     def test_bleaching_tags(self):
         """ Test provided tags are kept """
         context = Context(
@@ -45,5 +60,18 @@ class TestBleachTemplates(TestCase):
         rendered_template = template_to_render.render(context)
         self.assertInHTML(
             '<a href="http://{0}" rel="nofollow">{0}</a>'.format(url),
+            rendered_template
+        )
+        
+    def test_linkify_none(self):
+        """ Test bleach linkify with None as an input """
+        context = Context({'none_value': None})
+        template_to_render = Template(
+            '{% load bleach_tags %}'
+            '{{ none_value|bleach_linkify }}'
+        )
+        rendered_template = template_to_render.render(context)
+        self.assertEqual(
+            'None',
             rendered_template
         )

--- a/django_bleach/tests/test_templatetags.py
+++ b/django_bleach/tests/test_templatetags.py
@@ -62,7 +62,7 @@ class TestBleachTemplates(TestCase):
             '<a href="http://{0}" rel="nofollow">{0}</a>'.format(url),
             rendered_template
         )
-        
+
     def test_linkify_none(self):
         """ Test bleach linkify with None as an input """
         context = Context({'none_value': None})


### PR DESCRIPTION
Related to https://github.com/marksweb/django-bleach/pull/9

Due to bleach no longer accepting None as an input, django-bleach will throw exceptions if None is passed in. To maintain the existing behavior check for None in the templatetags.