### PR TITLE
Update URLs to fix 404

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ addresses in text that may be an HTML fragment to links, while preserving:
 3. email addresses
 
 
-.. _bleach: https://github.com/mozilla/bleach "Bleach"
-.. _bleach documentation: https://github.com/jsocol/bleach/blob/master/README.rst "Bleach documentation - parameters"
-.. _django-ckeditor: https://github.com/shaunsephton/django-ckeditor "Django CKEditor widget"
+.. _bleach: https://github.com/mozilla/bleach
+.. _bleach documentation: https://github.com/jsocol/bleach/blob/master/README.rst
+.. _django-ckeditor: https://github.com/shaunsephton/django-ckeditor
 .. _linkify: https://bleach.readthedocs.io/en/latest/linkify.html?highlight=linkify#bleach.linkify "linkify"


### PR DESCRIPTION
It looks that in _reStructuredText_, _titles_ cannot be given to hyperlinks, as opposed to that of markdown. 
```markdown
[Hyperlink](https://github.com "Title")
```
So, the title supplied in reST is appended at the end of the URL. `.. _bleach: https://github.com/mozilla/bleach "Bleach"`  is rendering anchor tag as `<a href="https://github.com/mozilla/bleach&quot;Bleach&quot;">Bleach</a>` , whereas the desired one is `<a href="https://github.com/mozilla/bleach" title="Bleach">Bleach</a>`. 

Simply put, clicking the link is taking the user to  `https://github.com/mozilla/bleach"Bleach"`  instead of `https://github.com/mozilla/bleach`, returning a 404 status code. All such links have been modified. 