### PR TITLE
Fix for #23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Version 0.7.2
+=============
+###### 27-07-2021
+*  Fix for [#23](https://github.com/marksweb/django-bleach/issues/23): `kwargs` being lost in the default form field.
+
 Version 0.7.1
 =============
 ###### 23-07-2021

--- a/django_bleach/__init__.py
+++ b/django_bleach/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 __author__ = "Tim Heap & Mark Walker"
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 VERSION = __version__.split(".")

--- a/django_bleach/models.py
+++ b/django_bleach/models.py
@@ -32,19 +32,19 @@ class BleachField(models.TextField):
     def formfield(self, **kwargs):
         """ Makes the field for a ModelForm """
 
-        # If field doesn't have any choice return BleachField
+        # If field doesn't have any choices return BleachField instead of `Textarea`
         if not self.choices:
-            return forms.BleachField(
-                label=self.verbose_name,
-                max_length=self.max_length,
-                allowed_tags=self.bleach_kwargs.get("tags"),
-                allowed_attributes=self.bleach_kwargs.get("attributes"),
-                allowed_styles=self.bleach_kwargs.get("styles"),
-                allowed_protocols=self.bleach_kwargs.get("protocols"),
-                strip_tags=self.bleach_kwargs.get("strip"),
-                strip_comments=self.bleach_kwargs.get("strip_comments"),
-                required=not self.blank,
-            )
+            kwargs.update({
+                'max_length': self.max_length,
+                'allowed_tags': self.bleach_kwargs.get("tags"),
+                'allowed_attributes': self.bleach_kwargs.get("attributes"),
+                'allowed_styles': self.bleach_kwargs.get("styles"),
+                'allowed_protocols': self.bleach_kwargs.get("protocols"),
+                'strip_tags': self.bleach_kwargs.get("strip"),
+                'strip_comments': self.bleach_kwargs.get("strip_comments"),
+                'required': not self.blank,
+            })
+            return forms.BleachField(**kwargs)
 
         return super(BleachField, self).formfield(**kwargs)
 

--- a/django_bleach/models.py
+++ b/django_bleach/models.py
@@ -32,17 +32,17 @@ class BleachField(models.TextField):
     def formfield(self, **kwargs):
         """ Makes the field for a ModelForm """
 
-        # If field doesn't have any choices return BleachField instead of `Textarea`
+        # If field doesn't have any choice return BleachField
         if not self.choices:
             kwargs.update({
-                'max_length': self.max_length,
-                'allowed_tags': self.bleach_kwargs.get("tags"),
-                'allowed_attributes': self.bleach_kwargs.get("attributes"),
-                'allowed_styles': self.bleach_kwargs.get("styles"),
-                'allowed_protocols': self.bleach_kwargs.get("protocols"),
-                'strip_tags': self.bleach_kwargs.get("strip"),
-                'strip_comments': self.bleach_kwargs.get("strip_comments"),
-                'required': not self.blank,
+                "max_length": self.max_length,
+                "allowed_tags": self.bleach_kwargs.get("tags"),
+                "allowed_attributes": self.bleach_kwargs.get("attributes"),
+                "allowed_styles": self.bleach_kwargs.get("styles"),
+                "allowed_protocols": self.bleach_kwargs.get("protocols"),
+                "strip_tags": self.bleach_kwargs.get("strip"),
+                "strip_comments": self.bleach_kwargs.get("strip_comments"),
+                "required": not self.blank,
             })
             return forms.BleachField(**kwargs)
 

--- a/django_bleach/tests/test_forms.py
+++ b/django_bleach/tests/test_forms.py
@@ -146,8 +146,7 @@ class TestBleachField(TestCase):
             test_data['bleach_styles']
         )
 
-    @patch('django_bleach.forms.settings',
-           BLEACH_DEFAULT_WIDGET='testproject.forms.CustomBleachWidget')
+    @patch('django_bleach.forms.settings', BLEACH_DEFAULT_WIDGET='testproject.forms.CustomBleachWidget')
     def test_custom_widget2(self, settings):
         self.assertEqual(
             settings.BLEACH_DEFAULT_WIDGET,

--- a/django_bleach/tests/test_modelformfield.py
+++ b/django_bleach/tests/test_modelformfield.py
@@ -14,7 +14,7 @@ class BleachContentModelForm(forms.ModelForm):
 
 
 class TestModelFormField(TestCase):
-    @override_settings(BLEACH_DEFAULT_WIDGET='testproject.forms.CustomBleachWidget')
+
     def setUp(self):
         model_form = BleachContentModelForm()
         self.form_field = model_form.fields['content']
@@ -29,6 +29,7 @@ class TestModelFormField(TestCase):
         """
         self.assertIsInstance(self.form_field, bleach_forms.BleachField)
 
+    @override_settings(BLEACH_DEFAULT_WIDGET='testproject.forms.CustomBleachWidget')
     def test_custom_widget(self):
         """
         Check content form field's widget is instance of default widget

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,9 @@ if sys.argv[-1] == 'build':
     os.system('python setup.py sdist bdist_wheel')
     sys.exit()
 
+if sys.argv[-1] == 'release':
+    os.system('twine upload -r django-bleach --skip-existing dist/*')
+    sys.exit()
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -69,4 +69,4 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware'
 )
 
-BLEACH_DEFAULT_WIDGET = 'testproject.forms.CustomBleachWidget'
+# BLEACH_DEFAULT_WIDGET = 'testproject.forms.CustomBleachWidget'


### PR DESCRIPTION
# Description

This fixes the issue of `kwargs` getting lost when `forms.BleachField` is used for a `ModelForm` field by default.

## References

#23 

# Checklist

* [x] I have ran `tox` to ensure tests pass
* [ ] Usage documentation added in case of new features
* [x] Tests added / I have not lowered coverage
