### PR TITLE
Respect form_class argument to support form field overrides

### DIFF
--- a/django_bleach/models.py
+++ b/django_bleach/models.py
@@ -29,10 +29,10 @@ class BleachField(models.TextField):
         if strip_comments:
             self.bleach_kwargs["strip_comments"] = strip_comments
 
-    def formfield(self, **kwargs):
+    def formfield(self, form_class=forms.BleachField, **kwargs):
         """ Makes the field for a ModelForm """
 
-        # If field doesn't have any choice return BleachField
+        # If field doesn't have any choices add kwargs expected by BleachField.
         if not self.choices:
             kwargs.update({
                 "max_length": self.max_length,
@@ -44,9 +44,8 @@ class BleachField(models.TextField):
                 "strip_comments": self.bleach_kwargs.get("strip_comments"),
                 "required": not self.blank,
             })
-            return forms.BleachField(**kwargs)
 
-        return super(BleachField, self).formfield(**kwargs)
+        return super(BleachField, self).formfield(form_class=form_class, **kwargs)
 
     def pre_save(self, model_instance, add):
         data = getattr(model_instance, self.attname)

--- a/django_bleach/tests/test_modelformfield.py
+++ b/django_bleach/tests/test_modelformfield.py
@@ -63,3 +63,29 @@ class TestModelFormField(TestCase):
         Check for the required flag on fields
         """
         self.assertEqual(self.form_field.required, True)
+
+
+class CustomBleachedFormField(bleach_forms.BleachField):
+    ...
+
+
+class OverriddenBleachContentModelForm(forms.ModelForm):
+    class Meta:
+        model = BleachContent
+        fields = '__all__'
+        field_classes = {
+            "content": CustomBleachedFormField,
+        }
+
+
+class TestModelFormFieldOverrides(TestCase):
+
+    def setUp(self):
+        model_form = OverriddenBleachContentModelForm()
+        self.form_field = model_form.fields['content']
+
+    def test_formfield_type(self):
+        """
+        Check content's form field is instance of CustomBleachedFormField.
+        """
+        self.assertIsInstance(self.form_field, CustomBleachedFormField)


### PR DESCRIPTION
Modifies the model field so the `formfield` method accepts an optional `form_class` argument as the `Field` parent class does and calls `super()` in all cases.

## References

Fixes #25

# Checklist

* [X] I have ran `tox` to ensure tests pass
* [x] Usage documentation added in case of new features
* [X] Tests added / I have not lowered coverage from 100%
