### PR TITLE
Fix custom widget tests

### DIFF
--- a/django_bleach/tests/test_forms.py
+++ b/django_bleach/tests/test_forms.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
-from django.test import TestCase
+from django import forms
+from django.test import TestCase, override_settings
 from django.utils.safestring import SafeString
-from mock import patch
 
 from django_bleach.forms import BleachField
-from testproject.forms import BleachForm
+from testproject.constants import (
+    ALLOWED_ATTRIBUTES,
+    ALLOWED_PROTOCOLS,
+    ALLOWED_STYLES,
+    ALLOWED_TAGS
+)
+from testproject.forms import BleachForm, CustomBleachWidget
 
 
 class TestBleachField(TestCase):
@@ -114,24 +120,69 @@ class TestBleachField(TestCase):
             '<ul><li>one</li><li>two</li></ul>'
         )
 
-    @patch('django_bleach.forms.settings',
-           BLEACH_DEFAULT_WIDGET='testproject.forms.CustomBleachWidget')
-    def test_custom_widget(self, settings):
 
-        self.assertEqual(
-            settings.BLEACH_DEFAULT_WIDGET,
-            'testproject.forms.CustomBleachWidget'
-        )
+@override_settings(BLEACH_DEFAULT_WIDGET='testproject.forms.CustomBleachWidget')
+class TestCustomWidget(TestCase):
+
+    def setUp(self):
+        class CustomForm(forms.Form):
+            # Define form inside function with overridden settings so
+            # get_default_widget() sees the modified setting.
+            no_tags = BleachField(
+                max_length=100,
+                strip_tags=True,
+                allowed_tags=[]
+            )
+            no_strip = BleachField(
+                max_length=100,
+                allowed_tags=None,
+                allowed_attributes=None
+            )
+            bleach_strip = BleachField(
+                max_length=100,
+                strip_comments=True,
+                strip_tags=True,
+                allowed_tags=ALLOWED_TAGS
+            )
+            bleach_attrs = BleachField(
+                max_length=100,
+                strip_tags=False,
+                allowed_tags=ALLOWED_TAGS,
+                allowed_protocols=ALLOWED_PROTOCOLS,
+                allowed_attributes=ALLOWED_ATTRIBUTES
+            )
+            bleach_styles = BleachField(
+                max_length=100,
+                strip_tags=False,
+                allowed_attributes=['style'],
+                allowed_tags=ALLOWED_TAGS,
+                allowed_styles=ALLOWED_STYLES
+            )
+        self.CustomForm = CustomForm
+
+    def test_custom_widget_type(self):
+        """ Test widget class matches BLEACH_DEFAULT_WIDGET """
+        for field in self.CustomForm().fields.values():
+            self.assertIsInstance(field.widget, CustomBleachWidget)
+
+    def test_custom_widget_bleaches_content(self):
+        """
+        Test input is bleached according to config while using a custom
+        widget
+        """
         test_data = {
-            'no_tags': "<h1>Heading</h1>",
-            'no_strip': "<h1>Heading</h1>",
-            'bleach_strip': "<!-- script here -->"
-                            "<script>alert(\"Hello World\")</script>",
-            'bleach_attrs': "<a href=\"http://www.google.com\" "
-                            "target=\"_blank\">google.com</a>",
-            'bleach_styles': "<li style=\"color: white\">item</li>"
+            'no_tags': '<h1>Heading</h1>',
+            'no_strip': '<h1>Heading</h1>',
+            'bleach_strip': '<!-- script here -->'
+                            '<script>alert("Hello World")</script>',
+            'bleach_attrs': (
+                '<a href="http://www.google.com" '
+                'target="_blank">google.com</a>'
+                '<a href="https://www.google.com">google.com</a>'
+            ),
+            'bleach_styles': '<li style="color: white">item</li>'
         }
-        form = BleachForm(data=test_data)
+        form = self.CustomForm(data=test_data)
         form.is_valid()
         self.assertEqual(
             form.cleaned_data['no_tags'], 'Heading'
@@ -146,44 +197,7 @@ class TestBleachField(TestCase):
         )
         self.assertEqual(
             form.cleaned_data['bleach_attrs'],
-            '<a>google.com</a>'
-        )
-        self.assertNotEqual(
-            form.cleaned_data['bleach_styles'],
-            test_data['bleach_styles']
-        )
-
-    @patch('django_bleach.forms.settings', BLEACH_DEFAULT_WIDGET='testproject.forms.CustomBleachWidget')
-    def test_custom_widget2(self, settings):
-        self.assertEqual(
-            settings.BLEACH_DEFAULT_WIDGET,
-            'testproject.forms.CustomBleachWidget'
-        )
-        test_data = {
-            'no_tags': "<h1>Heading</h1>",
-            'no_strip': "<h1>Heading</h1>",
-            'bleach_strip': "<!-- script here -->"
-                            "<script>alert(\"Hello World\")</script>",
-            'bleach_attrs': "<a href=\"https://www.google.com\" "
-                            "target=\"_blank\">google.com</a>",
-            'bleach_styles': "<li style=\"color: white\">item</li>"
-        }
-        form = BleachForm(data=test_data)
-        form.is_valid()
-        self.assertEqual(
-            form.cleaned_data['no_tags'], 'Heading'
-        )
-        self.assertEqual(
-            form.cleaned_data['no_strip'],
-            '&lt;h1&gt;Heading&lt;/h1&gt;'
-        )
-        self.assertEqual(
-            form.cleaned_data['bleach_strip'],
-            'alert("Hello World")'
-        )
-        self.assertEqual(
-            form.cleaned_data['bleach_attrs'],
-            '<a href="https://www.google.com">google.com</a>'
+            '<a>google.com</a><a href="https://www.google.com">google.com</a>'
         )
         self.assertNotEqual(
             form.cleaned_data['bleach_styles'],


### PR DESCRIPTION
# Description

Previous tests `test_custom_widget` and `test_custom_widget2` failed to override the BLEACH_DEFAULT_WIDGET at the correct time to influence the form being used to test thus the tests were not actually testing with the intended widget class. 

The reason the old tests were not correct is that `testproject.forms.BleachForm` is evaluated at compile time (with settings as per `testproject.settings`) while the mock only changes the settings when the individual test is run and it is too late. 

This PR defines a class within the `setUp` method of the test class while `override_settings` is in effect.

# Checklist

* [X] I have ran `tox` to ensure tests pass
* [X] Usage documentation added in case of new features
* [X] Tests added / I have not lowered coverage from 100%
