### PR TITLE
Mark saved data as safe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,9 +111,8 @@ accepts all of the normal field attributes. Behind the scenes, it is a
 ``TextField``, and accepts all the same arguments as the default ``TextField`` does.
 
 The ``BleachField`` model field sanitises its value before it is saved to the
-database. When the model is retrieved from the database, field values are
-automatically marked safe so they can be rendered in a template without further
-intervention.
+database and is marked safe so it can be immediately rendered in a template
+without further intervention.
 
 In model forms, ``BleachField`` model field are represented with the
 ``BleachField`` form field by default.

--- a/README.rst
+++ b/README.rst
@@ -110,19 +110,20 @@ In addition to the ``bleach``-specific arguments, the ``BleachField`` model fiel
 accepts all of the normal field attributes. Behind the scenes, it is a
 ``TextField``, and accepts all the same arguments as the default ``TextField`` does.
 
-The ``BleachField`` model field makes use of the ``BleachField`` form field to do
-all of the work. It provides no sanitisation facilities itself. This is
-considered a bug, but a clean solution has not yet been implemented. Any pull
-requests fixing this will be gratefully applied. As long as the ``BleachField``
-model field is only used with ``BleachField`` form fields, there will be no
-problem. If this is not the case, sanitised HTML can not be guaranteed.
+The ``BleachField`` model field sanitises its value before it is saved to the
+database. When the model is retrieved from the database, field values are
+automatically marked safe so they can be rendered in a template without further
+intervention.
+
+In model forms, ``BleachField`` model field are represented with the
+``BleachField`` form field by default.
 
 In your forms
 *************
 
 A ``BleachField`` form field is provided. This field sanitises HTML input from
-the user, and presents safe, clean HTML to your Django application. This is
-where most of the work is done.
+the user, and presents safe, clean HTML to your Django application and the
+returned value is marked safe for immediate rendering.
 
 In your templates
 *****************

--- a/django_bleach/models.py
+++ b/django_bleach/models.py
@@ -51,14 +51,11 @@ class BleachField(models.TextField):
 
     def pre_save(self, model_instance, add):
         data = getattr(model_instance, self.attname)
-        if data:
-            clean_value = clean(
-                data,
-                **self.bleach_kwargs
-            )
-            setattr(model_instance, self.attname, clean_value)
-            return clean_value
-        return data
+        if data is None:
+            return data
+        clean_value = clean(data, **self.bleach_kwargs) if data else ""
+        setattr(model_instance, self.attname, mark_safe(clean_value))
+        return clean_value
 
     def from_db_value(self, value, expression, connection):
         if value is None:

--- a/django_bleach/models.py
+++ b/django_bleach/models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.db import models
+from django.utils.safestring import mark_safe
 
 from bleach import clean
 
@@ -58,3 +59,10 @@ class BleachField(models.TextField):
             setattr(model_instance, self.attname, clean_value)
             return clean_value
         return data
+
+    def from_db_value(self, value, expression, connection):
+        if value is None:
+            return value
+        # Values are sanitised before saving, so any value returned from the DB
+        # is safe to render unescaped.
+        return mark_safe(value)

--- a/django_bleach/tests/test_models.py
+++ b/django_bleach/tests/test_models.py
@@ -26,6 +26,7 @@ class BleachContent(models.Model):
     )
     choice = BleachField(choices=CHOICES)
     blank_field = BleachField(blank=True)
+    null_field = BleachField(blank=True, null=True)
 
 
 class TestBleachModelField(TestCase):
@@ -71,6 +72,11 @@ class TestBleachModelField(TestCase):
         obj = BleachContent(content="")
         obj.save()
         self.assertIsInstance(obj.content, SafeString)
+
+    def test_saved_none_values_are_none(self):
+        obj = BleachContent(null_field=None)
+        obj.save()
+        self.assertIsNone(obj.null_field)
 
 
 class BleachNullableContent(models.Model):

--- a/django_bleach/tests/test_models.py
+++ b/django_bleach/tests/test_models.py
@@ -64,6 +64,14 @@ class TestBleachModelField(TestCase):
         obj.refresh_from_db()
         self.assertIsInstance(obj.content, SafeString)
 
+    def test_saved_values_are_template_safe(self):
+        obj = BleachContent(content="some content")
+        obj.save()
+        self.assertIsInstance(obj.content, SafeString)
+        obj = BleachContent(content="")
+        obj.save()
+        self.assertIsInstance(obj.content, SafeString)
+
 
 class BleachNullableContent(models.Model):
     """ Bleach test model"""

--- a/django_bleach/tests/test_models.py
+++ b/django_bleach/tests/test_models.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.db import models
 from django.test import TestCase
+from django.utils.safestring import SafeString
 
 from django_bleach.models import BleachField
 from testproject.constants import (
@@ -54,6 +55,14 @@ class TestBleachModelField(TestCase):
         for key, value in test_data.items():
             obj = BleachContent.objects.create(content=value)
             self.assertEqual(obj.content, expected_values[key])
+
+    def test_retrieved_values_are_template_safe(self):
+        obj = BleachContent.objects.create(content="some content")
+        obj.refresh_from_db()
+        self.assertIsInstance(obj.content, SafeString)
+        obj = BleachContent.objects.create(content="")
+        obj.refresh_from_db()
+        self.assertIsInstance(obj.content, SafeString)
 
 
 class BleachNullableContent(models.Model):

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -39,9 +39,12 @@ In addition to the bleach-specific arguments, the ``BleachField`` model field
 accepts all of the normal field attributes. Behind the scenes, it is a
 ``TextField``, and accepts all the same arguments as ``TextField``.
 
-The field does not specify any formfield to use, and falls back on the default
-``CharField`` and ``Textarea`` used by ``TextFields``. You must override the
-form field or widget yourself if you need something different.
+The ``BleachField`` model field sanitises its value before it is saved to the
+database and is marked safe so it can be immediately rendered in a template
+without further intervention.
+
+In model forms, ``BleachField`` model field are represented with the
+``BleachField`` form field by default.
 
 .. _forms:
 
@@ -49,12 +52,14 @@ In your forms
 =============
 
 A ``BleachField`` form field is provided. This field sanitises HTML input from
-the user, and presents safe, clean HTML to your Django application. This is
-where most of the work is done. Usually you will want to use a ``BleachField``
-model field, as opposed to the form field, but if you want, you can just use
-the form field. One possible use case for this set up is to force user input to
-be bleached, but allow administrators to add any content they like via another
-form (e.g. the admin site)::
+the user, and presents safe, clean HTML to your Django application and the
+returned value is marked safe for immediate rendering.
+
+Usually you will want to use a ``BleachField`` model field, as opposed to the
+form field, but if you want, you can just use the form field. One possible use
+case for this set up is to force user input to be bleached, but allow
+administrators to add any content they like via another form (e.g. the admin
+site)::
 
     # in app/forms.py
 


### PR DESCRIPTION
# Description

Marks bleach model field value as safe after the model is saved.

Fixes #35 but I went slightly further than the proposal and also marked the value safe in the in-memory object after it's saved.

I updated the README but not `/docs` - do you want those updated also?

# Checklist

* [X] I have ran `tox` to ensure tests pass
* [X] Usage documentation added in case of new features
* [X] Tests added / I have not lowered coverage from 100%
