### PR TITLE
feat: Update bleach to version >5.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install django==${{ matrix.django-version }} "bleach<5" coverage mock
+        pip install django==${{ matrix.django-version }} "bleach>=5,<6" coverage mock
         python setup.py install
     - name: Run coverage
       run: |
@@ -59,7 +59,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --pre django "bleach<5" coverage mock
+        pip install --pre django "bleach>=5,<6" coverage mock
         python setup.py install
     - name: Run tests
       run: |

--- a/django_bleach/forms.py
+++ b/django_bleach/forms.py
@@ -4,6 +4,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.safestring import mark_safe
 
 import bleach
+import warnings
+from bleach.css_sanitizer import CSSSanitizer
 from importlib import import_module
 
 from django_bleach.utils import get_bleach_default_options
@@ -43,7 +45,7 @@ class BleachField(forms.CharField):
 
     def __init__(self, allowed_tags=None, allowed_attributes=None,
                  allowed_styles=None, allowed_protocols=None,
-                 strip_comments=None, strip_tags=None, *args, **kwargs):
+                 strip_comments=None, strip_tags=None, css_sanitizer=None, *args, **kwargs):
 
         self.widget = get_default_widget()
 
@@ -56,7 +58,16 @@ class BleachField(forms.CharField):
         if allowed_attributes is not None:
             self.bleach_options["attributes"] = allowed_attributes
         if allowed_styles is not None:
-            self.bleach_options["styles"] = allowed_styles
+            warnings.warn(
+                "allowed_styles will be deprecated, use css_sanitizer instead",
+                DeprecationWarning
+            )
+
+            if css_sanitizer:
+                warnings.warn("allowed_styles argument is ignored since css_sanitizer is favoured over allowed_styles")
+            self.bleach_options["css_sanitizer"] = CSSSanitizer(allowed_css_properties=allowed_styles)
+        if css_sanitizer is not None:
+            self.bleach_options["css_sanitizer"] = css_sanitizer
         if allowed_protocols is not None:
             self.bleach_options["protocols"] = allowed_protocols
         if strip_tags is not None:

--- a/django_bleach/tests/test_forms.py
+++ b/django_bleach/tests/test_forms.py
@@ -97,7 +97,7 @@ class TestBleachField(TestCase):
         }
         form = BleachForm(data=test_data)
         form.is_valid()
-        self.assertEqual(form.cleaned_data['no_tags'], 'onetwo')
+        self.assertEqual(form.cleaned_data['no_tags'], '\none\ntwo')
 
         self.assertEqual(
             form.cleaned_data['bleach_strip'],

--- a/django_bleach/tests/test_forms.py
+++ b/django_bleach/tests/test_forms.py
@@ -2,8 +2,16 @@ from django import forms
 from django.test import TestCase, override_settings
 from django.utils.safestring import SafeString
 
+from bleach.css_sanitizer import CSSSanitizer
+
 from django_bleach.forms import BleachField
-from testproject.constants import ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS, ALLOWED_STYLES, ALLOWED_TAGS
+from testproject.constants import (
+    ALLOWED_ATTRIBUTES,
+    ALLOWED_CSS_PROPERTIES,
+    ALLOWED_PROTOCOLS,
+    ALLOWED_STYLES,
+    ALLOWED_TAGS,
+)
 from testproject.forms import BleachForm, CustomBleachWidget
 
 
@@ -21,6 +29,22 @@ class TestBleachField(TestCase):
         field = BleachField()
         self.assertIsInstance(field.to_python("some text"), SafeString)
 
+    def test_deprecation_allowed_styles(self):
+        with self.assertWarns(DeprecationWarning):
+            BleachField(allowed_styles=ALLOWED_STYLES)
+
+    def test_prefer_css_sanitizer_over_allowed_styles(self):
+        with self.assertWarnsMessage(
+            UserWarning,
+            "allowed_styles argument is ignored since css_sanitizer is favoured over allowed_styles"
+        ):
+            field = BleachField(
+                allowed_styles=['color', 'text-align'],
+                css_sanitizer=CSSSanitizer(allowed_css_properties=ALLOWED_CSS_PROPERTIES)
+            )
+            self.assertIsInstance(field.bleach_options["css_sanitizer"], CSSSanitizer)
+            self.assertEqual(field.bleach_options["css_sanitizer"].allowed_css_properties, ALLOWED_CSS_PROPERTIES)
+
     def test_bleaching(self):
         """ Test values are bleached """
         test_data = {
@@ -30,7 +54,7 @@ class TestBleachField(TestCase):
                             "<script>alert(\"Hello World\")</script>",
             'bleach_attrs': "<a href=\"https://www.google.com\" "
                             "target=\"_blank\">google.com</a>",
-            'bleach_styles': "<li style=\"color: white\">item</li>"
+            'bleach_css_sanitizer': "<li style=\"color: white\">item</li>",
         }
         form = BleachForm(data=test_data)
         form.is_valid()
@@ -50,8 +74,8 @@ class TestBleachField(TestCase):
             '<a href="https://www.google.com">google.com</a>'
         )
         self.assertNotEqual(
-            form.cleaned_data['bleach_styles'],
-            test_data['bleach_styles']
+            form.cleaned_data['bleach_css_sanitizer'],
+            test_data['bleach_css_sanitizer']
         )
 
     def test_tags(self):
@@ -62,7 +86,7 @@ class TestBleachField(TestCase):
             'bleach_strip': "<ul><li>one</li><li>two</li></ul>",
             'bleach_attrs': "<a href=\"https://www.google.com\" "
                             "title=\"Google\">google.com</a>",
-            'bleach_styles': "<li style=\"color: white;\">item</li>"
+            'bleach_css_sanitizer': "<li style=\"color: white;\">item</li>"
         }
         form = BleachForm(data=test_data)
         form.is_valid()
@@ -78,8 +102,8 @@ class TestBleachField(TestCase):
             test_data['bleach_attrs']
         )
         self.assertEqual(
-            form.cleaned_data['bleach_styles'],
-            test_data['bleach_styles']
+            form.cleaned_data['bleach_css_sanitizer'],
+            test_data['bleach_css_sanitizer']
         )
 
     def test_attrs(self):
@@ -93,7 +117,7 @@ class TestBleachField(TestCase):
             'no_tags': list_html,
             'bleach_strip': list_html,
             'bleach_attrs': list_html,
-            'bleach_styles': list_html
+            'bleach_css_sanitizer': list_html
         }
         form = BleachForm(data=test_data)
         form.is_valid()
@@ -108,7 +132,7 @@ class TestBleachField(TestCase):
             test_data['bleach_strip']
         )
         self.assertEqual(
-            form.cleaned_data['bleach_styles'],
+            form.cleaned_data['bleach_css_sanitizer'],
             '<ul><li>one</li><li>two</li></ul>'
         )
 
@@ -150,6 +174,13 @@ class TestCustomWidget(TestCase):
                 allowed_tags=ALLOWED_TAGS,
                 allowed_styles=ALLOWED_STYLES
             )
+            bleach_css_sanitizer = BleachField(
+                max_length=100,
+                strip_tags=False,
+                allowed_attributes=['style'],
+                allowed_tags=ALLOWED_TAGS,
+                css_sanitizer=CSSSanitizer(allowed_css_properties=ALLOWED_CSS_PROPERTIES)
+            )
         self.CustomForm = CustomForm
 
     def test_custom_widget_type(self):
@@ -172,7 +203,8 @@ class TestCustomWidget(TestCase):
                 'target="_blank">google.com</a>'
                 '<a href="https://www.google.com">google.com</a>'
             ),
-            'bleach_styles': '<li style="color: white">item</li>'
+            'bleach_styles': '<li style="color: white">item</li>',
+            'bleach_css_sanitizer': '<li style="color: white">item</li>'
         }
         form = self.CustomForm(data=test_data)
         form.is_valid()
@@ -194,4 +226,8 @@ class TestCustomWidget(TestCase):
         self.assertNotEqual(
             form.cleaned_data['bleach_styles'],
             test_data['bleach_styles']
+        )
+        self.assertNotEqual(
+            form.cleaned_data['bleach_css_sanitizer'],
+            test_data['bleach_css_sanitizer']
         )

--- a/django_bleach/tests/test_settings.py
+++ b/django_bleach/tests/test_settings.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.forms import Textarea
 from django.test import TestCase, override_settings
 
+from bleach.css_sanitizer import CSSSanitizer
 from unittest.mock import patch
 
 from django_bleach.forms import get_default_widget
@@ -28,7 +29,8 @@ class TestBleachOptions(TestCase):
            BLEACH_ALLOWED_STYLES=ALLOWED_STYLES)
     def test_custom_styles(self, settings):
         bleach_args = get_bleach_default_options()
-        self.assertEqual(bleach_args['styles'], ALLOWED_STYLES)
+        self.assertIsInstance(bleach_args['css_sanitizer'], CSSSanitizer)
+        self.assertEqual(bleach_args['css_sanitizer'].allowed_css_properties, ALLOWED_STYLES)
 
     @patch('django_bleach.utils.settings', BLEACH_ALLOWED_TAGS=ALLOWED_TAGS)
     def test_custom_tags(self, settings):

--- a/django_bleach/tests/test_settings.py
+++ b/django_bleach/tests/test_settings.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from django_bleach.forms import get_default_widget
 from django_bleach.utils import get_bleach_default_options
-from testproject.constants import ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS, ALLOWED_STYLES, ALLOWED_TAGS
+from testproject.constants import ALLOWED_ATTRIBUTES, ALLOWED_CSS_PROPERTIES, ALLOWED_PROTOCOLS, ALLOWED_TAGS
 from testproject.forms import CustomBleachWidget
 
 
@@ -26,11 +26,11 @@ class TestBleachOptions(TestCase):
         self.assertEqual(bleach_args['protocols'], ALLOWED_PROTOCOLS)
 
     @patch('django_bleach.utils.settings',
-           BLEACH_ALLOWED_STYLES=ALLOWED_STYLES)
+           BLEACH_ALLOWED_STYLES=ALLOWED_CSS_PROPERTIES)
     def test_custom_styles(self, settings):
         bleach_args = get_bleach_default_options()
         self.assertIsInstance(bleach_args['css_sanitizer'], CSSSanitizer)
-        self.assertEqual(bleach_args['css_sanitizer'].allowed_css_properties, ALLOWED_STYLES)
+        self.assertEqual(bleach_args['css_sanitizer'].allowed_css_properties, ALLOWED_CSS_PROPERTIES)
 
     @patch('django_bleach.utils.settings', BLEACH_ALLOWED_TAGS=ALLOWED_TAGS)
     def test_custom_tags(self, settings):

--- a/django_bleach/utils.py
+++ b/django_bleach/utils.py
@@ -1,12 +1,14 @@
 from django.conf import settings
 
+from bleach.css_sanitizer import CSSSanitizer
+
 
 def get_bleach_default_options():
     bleach_args = {}
     bleach_settings = {
         "BLEACH_ALLOWED_TAGS": "tags",
         "BLEACH_ALLOWED_ATTRIBUTES": "attributes",
-        "BLEACH_ALLOWED_STYLES": "styles",
+        "BLEACH_ALLOWED_STYLES": "css_sanitizer",
         "BLEACH_STRIP_TAGS": "strip",
         "BLEACH_STRIP_COMMENTS": "strip_comments",
         "BLEACH_ALLOWED_PROTOCOLS": "protocols"
@@ -14,6 +16,9 @@ def get_bleach_default_options():
 
     for setting, kwarg in bleach_settings.items():
         if hasattr(settings, setting):
-            bleach_args[kwarg] = getattr(settings, setting)
+            attr = getattr(settings, setting)
+            if setting == "BLEACH_ALLOWED_STYLES":
+                attr = CSSSanitizer(allowed_css_properties=attr)
+            bleach_args[kwarg] = attr
 
     return bleach_args

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -39,14 +39,18 @@ completely optional::
 
 You can override each of these for individual ``BleachField`` form and model
 fields if you need to. Simply pass in one of the following settings you want to
-override as a named parameter to the ``BleachField``::
+override as a named parameter to the ``BleachField``:
 
 * ``allowed_tags``
 * ``allowed_attributes``
-* ``allowed_styles``
 * ``allowed_protocols``
 * ``strip_tags``
 * ``strip_comments``
+* ``css_sanitizer``
+
+The following argument will be deprecated in the near future:
+
+* ``allowed_styles``
 
 An example, where blog posts should be allowed to contain images and headings::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -30,10 +30,14 @@ See the bleach documentation for their use:
 
 * ``allowed_tags``
 * ``allowed_attributes``
-* ``allowed_styles``
 * ``allowed_protocols``
 * ``strip_tags``
 * ``strip_comments``
+* ``css_sanitizer``
+
+The following argument will be deprecated in the near future:
+
+* ``allowed_styles``
 
 In addition to the bleach-specific arguments, the ``BleachField`` model field
 accepts all of the normal field attributes. Behind the scenes, it is a

--- a/setup.py
+++ b/setup.py
@@ -68,11 +68,11 @@ setup(
     license='MIT',
     packages=find_packages(exclude=('testproject*',)),
     install_requires=[
-        'bleach[css]>=5.0.0',
+        'bleach[css]>=5,<6',
         'Django>=1.11',
     ],
     tests_require=[
-        'bleach>=5.0.0',
+        'bleach[css]>=5,<6',
         'mock',
         'sphinx',
         'tox'

--- a/setup.py
+++ b/setup.py
@@ -68,11 +68,11 @@ setup(
     license='MIT',
     packages=find_packages(exclude=('testproject*',)),
     install_requires=[
-        'bleach>=1.5.0,<5',
+        'bleach[css]>=5.0.0',
         'Django>=1.11',
     ],
     tests_require=[
-        'bleach>=1.5.0',
+        'bleach>=5.0.0',
         'mock',
         'sphinx',
         'tox'

--- a/testproject/constants.py
+++ b/testproject/constants.py
@@ -3,14 +3,16 @@ ALLOWED_ATTRIBUTES = {
     'a': ['href', 'title']
 }
 
+ALLOWED_CSS_PROPERTIES = [
+    'color'
+]
+
 ALLOWED_PROTOCOLS = [
     'https',
     'data',
 ]
 
-ALLOWED_STYLES = [
-    'color'
-]
+ALLOWED_STYLES = ALLOWED_CSS_PROPERTIES
 
 ALLOWED_TAGS = [
     'a',

--- a/testproject/forms.py
+++ b/testproject/forms.py
@@ -1,7 +1,15 @@
 from django import forms
 
+from bleach.css_sanitizer import CSSSanitizer
+
 from django_bleach.forms import BleachField
-from testproject.constants import ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS, ALLOWED_STYLES, ALLOWED_TAGS
+from testproject.constants import (
+    ALLOWED_ATTRIBUTES,
+    ALLOWED_CSS_PROPERTIES,
+    ALLOWED_PROTOCOLS,
+    ALLOWED_STYLES,
+    ALLOWED_TAGS,
+)
 from testproject.models import Person
 
 
@@ -46,6 +54,13 @@ class BleachForm(forms.Form):
         allowed_attributes=['style'],
         allowed_tags=ALLOWED_TAGS,
         allowed_styles=ALLOWED_STYLES
+    )
+    bleach_css_sanitizer = BleachField(
+        max_length=100,
+        strip_tags=False,
+        allowed_attributes=['style'],
+        allowed_tags=ALLOWED_TAGS,
+        css_sanitizer=CSSSanitizer(allowed_css_properties=ALLOWED_CSS_PROPERTIES)
     )
 
 

--- a/testproject/models.py
+++ b/testproject/models.py
@@ -1,5 +1,7 @@
 from django.db import models
 
+from bleach.css_sanitizer import CSSSanitizer
+
 from django_bleach.models import BleachField
 
 
@@ -11,5 +13,5 @@ class Person(models.Model):
         allowed_tags=['p', 'a', 'li', 'ul', 'strong'],
         allowed_attributes=['class', 'href', 'style'],
         allowed_protocols=['http', 'https'],
-        allowed_styles=['color', 'background-color']
+        css_sanitizer=CSSSanitizer(allowed_css_properties=['color', 'background-color'])
     )

--- a/testproject/requirements.txt
+++ b/testproject/requirements.txt
@@ -14,7 +14,7 @@ attrs==21.4.0
     #   flake8-eradicate
 babel==2.9.1
     # via sphinx
-bleach==4.1.0
+bleach==5.0.0
     # via -r requirements.in
 certifi==2021.10.8
     # via requests


### PR DESCRIPTION
# Description
Update bleach to new major version

Describe:

Update the dependency bleach to next major version.
For backward compatibility allowed_styles is still a keyword argument on all functions. This argument will be replaced by css_sanitizer.  
Allowed_styles should be deprecated in the near feature in order to still comply with same function arguments as bleach. This should be included in the next major release.


## References

- #51

# Checklist

* [x] I have ran `tox` to ensure tests pass
* [x] Usage documentation added in case of new features
* [x] Tests added / I have not lowered coverage from 100%
