### PR TITLE
Increase Django max version to 4.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         django-version: [
             '3.2',
             '4.0',
+            '4.1',
         ]
         os: [
           ubuntu-20.04,

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.1',
         'Development Status :: 5 - Production/Stable',
     ],
     project_urls={

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ setenv =
 deps =
     bleach
     django32: Django>=3.2,<3.3
-    django4: Django>=4.0,<4.1
+    django4: Django>=4.0,<4.2
     mock
 
 extras =


### PR DESCRIPTION
# Description

I'm intending to use this on a Django 4.1 project, so I wanted to increase the maximum Django version to 4.1 and add 4.1 to the tested versions. There aren't any code changes.

There may be more work to do, but I wanted this PR to at least get things started. Not a draft in case this PR is good-to-go as is.

[4.0's active support has ended, and its security support will end in <6 months](https://endoflife.date/django).

# Checklist

* [x] I have ran `tox` to ensure tests pass
* [ ] Usage documentation added in case of new features
* [ ] README & CHANGELOG updated
* [ ] Tests added / I have not lowered coverage from 100%
